### PR TITLE
Fire the upscript in case of a master is reasserting control

### DIFF
--- a/src/carp.c
+++ b/src/carp.c
@@ -585,6 +585,7 @@ static void packethandler(unsigned char *dummy,
             if (timercmp(&sc_tv, &ch_tv, <) ||
                 (timercmp(&sc_tv, &ch_tv, ==) &&
                     iphead.ip_src.s_addr > srcip.s_addr)) {
+                (void) spawn_handler(dev_desc_fd, upscript);
                 gratuitous_arp(dev_desc_fd);
                 sc.sc_delayed_arp = garp_timeout; /* and until garp_timeout */
                 logfile(LOG_WARNING, _("Non-preferred master advertising: "


### PR DESCRIPTION
Fire the _upscript_ in case of a preferred master is reasserting control, too. The master will send gratuitous arp for the primary VIP. But there may be more then one provided by the up script. Also, it might be need to perform some actions if another instance have be become a master temporary and fired the upscript there.